### PR TITLE
Mexplico

### DIFF
--- a/ESPmaster_ArduinoSlave/ESPmaster/ESPmaster.ino
+++ b/ESPmaster_ArduinoSlave/ESPmaster/ESPmaster.ino
@@ -49,7 +49,7 @@ analog read           4     pin       0(else)
 store variable        5     nVar      value
 get  variable         6     nvar      0(else)
 configure pin         7     pin       confVal
-send eeprom values    8     0         0(else)
+Get pinConf           8     0         0(else)
 clear pinConf         8     1         0(else)
 reset arduino         9     0(else)   0(esle) */
 


### PR DESCRIPTION
Puse esta opción en un intento de evitar mandar 8.1.0 (clear pin conf) en cada reinicio.
Slave comprueva si cambia un valodr de pin conf y entonces needReset=1
Ademas de asignar configuración a los pines que usamos, seria mejor dar valor de configuración 0 o >5 a los otros, así no usaríamos eeprom en cada reinicio, y evitaríamos que arduino sea inestable por tener pines configurados y no conectados¿no?
no se si me explico, es un tema resuelto mandando clear pero me gustaría no hacerlo así
